### PR TITLE
chore: node engine downgrade [#1208991149265753]

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
 	"version": "1.0.0",
 	"private": true,
 	"engines": {
-		"node": ">=20.10.0",
-		"npm": ">=10.0.0"
+		"node": ">=20.0.0"
 	},
 	"scripts": {
 		"setup": "npm ci",


### PR DESCRIPTION
## Description

Dependabot uses Node.js v20.18.1.

Seeing that we don't really need 22 until 20 reaches end of life (Apr 2026), I'm downgrading our requirements so that it can do its thing.

## Asana

[Asana card link](https://app.asana.com/0/0/1208991149265753).